### PR TITLE
updated spotify-web-api-node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "license": "MIT",
   "devDependencies": {},
   "dependencies": {
-    "spotify-web-api-node": "~2.0.1",
+    "spotify-web-api-node": "~2.2.0",
     "dotenv": "~1.0.0",
     "express": "~4.12.3",
     "request": "~2.53.0",


### PR DESCRIPTION
retrieving an access token through the Client Credentials flow didn't work with the current version of spotify-web-api-node.